### PR TITLE
Revert "chore: deps: bump github.com/shaj13/libcache from 1.0.4 to 1.2.1 in /qubership-apihub-agent"

### DIFF
--- a/qubership-apihub-agent/go.mod
+++ b/qubership-apihub-agent/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/netcracker/qubership-core-lib-go-paas-mediation-client/v8 v8.0.0-20250410143905-3d0ae9284c45
 	github.com/netcracker/qubership-core-lib-go/v3 v3.0.0-20250410090100-eded4c69a462
 	github.com/shaj13/go-guardian/v2 v2.11.6
-	github.com/shaj13/libcache v1.2.1
+	github.com/shaj13/libcache v1.0.4
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.10.0
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2


### PR DESCRIPTION
Reverts Netcracker/qubership-apihub-agent#25