### PR TITLE
feat: secure TLS for HTTP clients

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Note: this uses host platform for the build, and we ask go build to target the needed platform, so we do not spend time on qemu emulation when running "go build"
-FROM --platform=$BUILDPLATFORM docker.io/golang:1.26.1-alpine3.23 as builder
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.26.1-alpine3.23 AS builder
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
@@ -28,7 +28,7 @@ RUN go mod tidy
 
 RUN GOSUMDB=off CGO_ENABLED=0 go mod tidy && go mod download && GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build .
 
-FROM docker.io/alpine:3.23
+FROM ghcr.io/netcracker/qubership-core-base:2.3.3@sha256:1339716127a7d170ba307b89f3a933f5e09c447607c89e16bf8d5a379db4e1f6
 
 ARG GIT_BRANCH=unknown
 ARG GIT_HASH=unknown
@@ -36,17 +36,10 @@ ARG GIT_HASH=unknown
 ENV GIT_BRANCH=$GIT_BRANCH
 ENV GIT_HASH=$GIT_HASH
 
-USER root
-
-# hadolint ignore=DL3018
-RUN apk --no-cache add curl
-
 WORKDIR /app/qubership-apihub-agent
 
-COPY --from=builder /workspace/qubership-apihub-agent/qubership-apihub-agent ./qubership-apihub-agent
+COPY --chown=10001:0 --chmod=555 --from=builder /workspace/qubership-apihub-agent/qubership-apihub-agent ./qubership-apihub-agent
 
-RUN chmod -R a+rwx /app
+USER 10001:10001
 
-USER 10001
-
-ENTRYPOINT ["./qubership-apihub-agent"]
+CMD ["./qubership-apihub-agent"]

--- a/helm-templates/README.md
+++ b/helm-templates/README.md
@@ -27,8 +27,9 @@ It is ready for usage Helm chart.
 1. Download Qubership APIHUB Agent helm chart
 2. Review [`config.template.yaml`](../qubership-apihub-agent/config.template.yaml) for the full list of configuration parameters and their descriptions
 3. Fill `values.yaml` with your deploy parameters:
-   - Helm-specific settings (image, resources) are at the top level under `qubershipApihubAgent`
+   - Helm-specific settings (image, resources, `goMemLimit`) are at the top level under `qubershipApihubAgent`
    - Application configuration is under `qubershipApihubAgent.env` and follows the same structure as `config.template.yaml`
+   - Keep `goMemLimit` below `resource.memory.limit` (~80% of the limit in chart defaults)
 
 ## Execute helm install
 

--- a/helm-templates/README.md
+++ b/helm-templates/README.md
@@ -60,3 +60,23 @@ Execute the following command to deploy Qubership APIHUB Agent:
 ```bash
 helm install qubership-apihub-agent -n qubership-apihub-agent --create-namespace -f ./qubership-apihub-agent/local-k8s-values.yaml ./qubership-apihub-agent
 ```
+
+## Custom CA certificates
+
+The agent runtime image is based on `ghcr.io/netcracker/qubership-core-base`. Custom CA certificates are loaded into the system trust store by the base image entrypoint from `/tmp/cert/` before the application starts.
+
+1. Mount `.crt`, `.cer`, or `.pem` files into `/tmp/cert/` (Compose volume or Kubernetes Secret/ConfigMap mount).
+2. The entrypoint runs `update-ca-certificates` and Go HTTP clients use `x509.SystemCertPool()` automatically.
+
+Example Kubernetes volume mount:
+
+```yaml
+volumeMounts:
+  - name: custom-ca
+    mountPath: /tmp/cert
+    readOnly: true
+volumes:
+  - name: custom-ca
+    secret:
+      secretName: apihub-custom-ca
+```

--- a/helm-templates/README.md
+++ b/helm-templates/README.md
@@ -65,18 +65,22 @@ helm install qubership-apihub-agent -n qubership-apihub-agent --create-namespace
 
 The agent runtime image is based on `ghcr.io/netcracker/qubership-core-base`. Custom CA certificates are loaded into the system trust store by the base image entrypoint from `/tmp/cert/` before the application starts.
 
-1. Mount `.crt`, `.cer`, or `.pem` files into `/tmp/cert/` (Compose volume or Kubernetes Secret/ConfigMap mount).
-2. The entrypoint runs `update-ca-certificates` and Go HTTP clients use `x509.SystemCertPool()` automatically.
-
-Example Kubernetes volume mount:
+1. Create a Kubernetes Secret with one or more `.crt`, `.cer`, or `.pem` files.
+2. Enable the optional Helm mount:
 
 ```yaml
-volumeMounts:
-  - name: custom-ca
-    mountPath: /tmp/cert
-    readOnly: true
-volumes:
-  - name: custom-ca
-    secret:
-      secretName: apihub-custom-ca
+qubershipApihubAgent:
+  customCa:
+    enabled: true
+    secretName: apihub-agent-custom-ca
 ```
+
+Example:
+
+```bash
+kubectl create secret generic apihub-agent-custom-ca \
+  --from-file=company-ca.pem=./company-ca.pem \
+  -n qubership-apihub-agent
+```
+
+Default remains `customCa.enabled: false` (no mount).

--- a/helm-templates/qubership-apihub-agent/local-k8s-values.yaml
+++ b/helm-templates/qubership-apihub-agent/local-k8s-values.yaml
@@ -15,6 +15,10 @@ qubershipApihubAgent:
 
   logLevel: "INFO"
 
+  customCa:
+    enabled: false
+    secretName: ''
+
   env:
     technicalParameters:
       apihub:

--- a/helm-templates/qubership-apihub-agent/templates/Deployment.yaml
+++ b/helm-templates/qubership-apihub-agent/templates/Deployment.yaml
@@ -1,3 +1,4 @@
+# yamllint disable-file
 ---
 kind: Deployment
 apiVersion: apps/v1

--- a/helm-templates/qubership-apihub-agent/templates/Deployment.yaml
+++ b/helm-templates/qubership-apihub-agent/templates/Deployment.yaml
@@ -34,6 +34,12 @@ spec:
             secretName: qubership-apihub-agent-config-secret
         - name: tmp-volume
           emptyDir: {}
+        {{- if and .Values.qubershipApihubAgent.customCa.enabled .Values.qubershipApihubAgent.customCa.secretName }}
+        - name: qubership-apihub-agent-custom-ca
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.qubershipApihubAgent.customCa.secretName | quote }}
+        {{- end }}
       hostPID: false
       hostIPC: false
       containers:
@@ -45,6 +51,11 @@ spec:
               readOnly: true
             - name: tmp-volume
               mountPath: /tmp
+            {{- if and .Values.qubershipApihubAgent.customCa.enabled .Values.qubershipApihubAgent.customCa.secretName }}
+            - name: qubership-apihub-agent-custom-ca
+              mountPath: /tmp/cert
+              readOnly: true
+            {{- end }}
           ports:
             - name: web
               containerPort: 8080

--- a/helm-templates/qubership-apihub-agent/templates/Deployment.yaml
+++ b/helm-templates/qubership-apihub-agent/templates/Deployment.yaml
@@ -64,6 +64,8 @@ spec:
           env:
             - name: LOG_LEVEL
               value: '{{ .Values.qubershipApihubAgent.logLevel }}'
+            - name: GOMEMLIMIT
+              value: '{{ .Values.qubershipApihubAgent.goMemLimit | default "205MiB" }}'
             - name: AGENT_CONFIG_FOLDER
               value: '/app/qubership-apihub-agent/etc/'
           resources:

--- a/helm-templates/qubership-apihub-agent/values.yaml
+++ b/helm-templates/qubership-apihub-agent/values.yaml
@@ -16,6 +16,9 @@ qubershipApihubAgent:
       request: "30m"
       limit: "1"
 
+  # Optional; Go runtime memory soft limit passed as GOMEMLIMIT (container env). Keep below resource.memory.limit; If not set, default value: 205MiB (~80% of default memory.limit 256Mi); Example: 2400MiB
+  goMemLimit: '205MiB'
+
   # Optional; Set log level on init to specified value. Values: Info, Warn, Error, etc; If not set, default value: INFO; Example: DEBUG
   logLevel: ''
 

--- a/helm-templates/qubership-apihub-agent/values.yaml
+++ b/helm-templates/qubership-apihub-agent/values.yaml
@@ -19,6 +19,15 @@ qubershipApihubAgent:
   # Optional; Set log level on init to specified value. Values: Info, Warn, Error, etc; If not set, default value: INFO; Example: DEBUG
   logLevel: ''
 
+  # Optional; custom CA certificates for agent HTTPS outbound calls (APIHUB, agents-backend, discovery, service proxy).
+  # Requires the qubership-core-base runtime image. The base image entrypoint loads .crt/.cer/.pem files from
+  # /tmp/cert into the system trust store before the application starts.
+  customCa:
+    # Optional; mount custom CA Secret when true; If not set, default value: false; Example: true
+    enabled: false
+    # Optional; Kubernetes Secret name with one or more PEM certificate files (.crt, .cer, or .pem keys); If not set, default value: ""; Example: apihub-agent-custom-ca
+    secretName: ''
+
   # Section with business and technical parameters for Qubership APIHUB Agent.
   env:
     # Section with technical parameters

--- a/qubership-apihub-agent/client/agents_backend.go
+++ b/qubership-apihub-agent/client/agents_backend.go
@@ -1,13 +1,13 @@
 package client
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/Netcracker/qubership-apihub-agent/secctx"
+	"github.com/Netcracker/qubership-apihub-agent/utils"
 	"github.com/Netcracker/qubership-apihub-agent/view"
 	"gopkg.in/resty.v1"
 )
@@ -16,13 +16,22 @@ type AgentsBackendClient interface {
 	SendKeepaliveMessage(pathPrefix string, msg view.AgentKeepaliveMessage) (string, error)
 }
 
-func NewAgentsBackendClient(apihubUrl string, accessToken string) AgentsBackendClient {
-	return &agentsBackendClientImpl{apihubUrl: apihubUrl, accessToken: accessToken}
+func NewAgentsBackendClient(apihubUrl string, accessToken string) (AgentsBackendClient, error) {
+	httpClient, err := utils.CreateSecureHTTPClient(time.Second * 60)
+	if err != nil {
+		return nil, err
+	}
+	return &agentsBackendClientImpl{
+		apihubUrl:   apihubUrl,
+		accessToken: accessToken,
+		restyClient: resty.NewWithClient(httpClient),
+	}, nil
 }
 
 type agentsBackendClientImpl struct {
 	apihubUrl   string
 	accessToken string
+	restyClient *resty.Client
 }
 
 func (a agentsBackendClientImpl) SendKeepaliveMessage(pathPrefix string, msg view.AgentKeepaliveMessage) (string, error) {
@@ -56,11 +65,7 @@ func (a agentsBackendClientImpl) SendKeepaliveMessage(pathPrefix string, msg vie
 }
 
 func (a agentsBackendClientImpl) makeRequest(ctx secctx.SecurityContext) *resty.Request {
-	tr := http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
-	cl := http.Client{Transport: &tr, Timeout: time.Second * 60}
-
-	client := resty.NewWithClient(&cl)
-	req := client.R()
+	req := a.restyClient.R()
 	if ctx.GetUserToken() != "" {
 		req.SetHeader("Authorization", fmt.Sprintf("Bearer %s", ctx.GetUserToken()))
 	} else {

--- a/qubership-apihub-agent/client/apihub.go
+++ b/qubership-apihub-agent/client/apihub.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/Netcracker/qubership-apihub-agent/exception"
 	"github.com/Netcracker/qubership-apihub-agent/secctx"
+	"github.com/Netcracker/qubership-apihub-agent/utils"
 	"github.com/Netcracker/qubership-apihub-agent/view"
 	"gopkg.in/resty.v1"
 )
@@ -35,14 +35,24 @@ type ApihubClient interface {
 	GetApiKeyByKey(ctx context.Context, apiKey string) (*view.ApihubApiKeyView, error)
 }
 
-func NewApihubClient(apihubUrl string, accessToken string, cloudName string) ApihubClient {
-	return &apihubClientImpl{apihubUrl: apihubUrl, accessToken: accessToken, cloudName: cloudName}
+func NewApihubClient(apihubUrl string, accessToken string, cloudName string) (ApihubClient, error) {
+	httpClient, err := utils.CreateSecureHTTPClient(time.Second * 60)
+	if err != nil {
+		return nil, err
+	}
+	return &apihubClientImpl{
+		apihubUrl:   apihubUrl,
+		accessToken: accessToken,
+		cloudName:   cloudName,
+		restyClient: resty.NewWithClient(httpClient),
+	}, nil
 }
 
 type apihubClientImpl struct {
 	apihubUrl   string
 	accessToken string
 	cloudName   string
+	restyClient *resty.Client
 }
 
 func checkUnauthorized(resp *resty.Response) error {
@@ -161,11 +171,7 @@ func (a apihubClientImpl) GetUserPackagesPromoteStatuses(ctx secctx.SecurityCont
 }
 
 func (a apihubClientImpl) CheckApiKeyValid(apiKey string) (bool, error) {
-	tr := http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
-	cl := http.Client{Transport: &tr, Timeout: time.Second * 60}
-
-	client := resty.NewWithClient(&cl)
-	req := client.R()
+	req := a.restyClient.R()
 
 	req.SetHeader("api-key", apiKey)
 
@@ -180,11 +186,7 @@ func (a apihubClientImpl) CheckApiKeyValid(apiKey string) (bool, error) {
 }
 
 func (a apihubClientImpl) CheckAuthToken(ctx context.Context, token string) (bool, error) {
-	tr := http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
-	cl := http.Client{Transport: &tr, Timeout: time.Second * 60}
-
-	client := resty.NewWithClient(&cl)
-	req := client.R()
+	req := a.restyClient.R()
 	req.SetContext(ctx)
 	req.SetHeader("Cookie", fmt.Sprintf("%s=%s", view.AccessTokenCookieName, token))
 
@@ -216,11 +218,7 @@ func (a apihubClientImpl) GetSystemConfiguration() (*view.ApihubSystemConfigurat
 }
 
 func (a apihubClientImpl) GetApiKeyByKey(ctx context.Context, apiKey string) (*view.ApihubApiKeyView, error) {
-	tr := http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
-	cl := http.Client{Transport: &tr, Timeout: time.Second * 60}
-
-	client := resty.NewWithClient(&cl)
-	req := client.R()
+	req := a.restyClient.R()
 	req.SetContext(ctx)
 	req.SetHeader("api-key", apiKey)
 
@@ -242,11 +240,7 @@ func (a apihubClientImpl) GetApiKeyByKey(ctx context.Context, apiKey string) (*v
 }
 
 func (a apihubClientImpl) makeRequest(ctx secctx.SecurityContext) *resty.Request {
-	tr := http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
-	cl := http.Client{Transport: &tr, Timeout: time.Second * 60}
-
-	client := resty.NewWithClient(&cl)
-	req := client.R()
+	req := a.restyClient.R()
 	if ctx.GetUserToken() != "" {
 		req.SetHeader("Authorization", fmt.Sprintf("Bearer %s", ctx.GetUserToken()))
 	} else {

--- a/qubership-apihub-agent/client/spec.go
+++ b/qubership-apihub-agent/client/spec.go
@@ -12,7 +12,10 @@ import (
 )
 
 func GetRawGraphqlIntrospectionFromUrl(url string, timeout time.Duration) ([]byte, error) {
-	client := utils.MakeDiscoveryHttpClient(timeout)
+	client, err := utils.MakeDiscoveryHttpClient(timeout)
+	if err != nil {
+		return nil, err
+	}
 
 	start := time.Now()
 	req, err := http.NewRequest(http.MethodPost, url, nil)
@@ -46,7 +49,10 @@ func GetRawGraphqlIntrospectionFromUrl(url string, timeout time.Duration) ([]byt
 }
 
 func GetRawDocumentFromUrl(url, documentType string, timeout time.Duration) ([]byte, error) {
-	client := utils.MakeDiscoveryHttpClient(timeout)
+	client, err := utils.MakeDiscoveryHttpClient(timeout)
+	if err != nil {
+		return nil, err
+	}
 	start := time.Now()
 	resp, err := client.Get(url)
 	if err != nil {

--- a/qubership-apihub-agent/controller/service_proxy.go
+++ b/qubership-apihub-agent/controller/service_proxy.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"crypto/tls"
 	"fmt"
 	"github.com/Netcracker/qubership-apihub-agent/view"
 	"io"
@@ -15,11 +14,15 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func NewServiceProxyController(discoveryService service.DiscoveryService) ProxyController {
-	return &serviceProxyControllerImpl{
-		tr:               http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
-		discoveryService: discoveryService,
+func NewServiceProxyController(discoveryService service.DiscoveryService) (ProxyController, error) {
+	tlsConfig, err := utils.BuildSecureTLSConfig(nil)
+	if err != nil {
+		return nil, err
 	}
+	return &serviceProxyControllerImpl{
+		tr:               http.Transport{TLSClientConfig: tlsConfig},
+		discoveryService: discoveryService,
+	}, nil
 }
 
 type serviceProxyControllerImpl struct {

--- a/qubership-apihub-agent/service.go
+++ b/qubership-apihub-agent/service.go
@@ -61,6 +61,9 @@ func main() {
 		log.Error("Failed to read system info: " + err.Error())
 		panic("Failed to read system info: " + err.Error())
 	}
+	if err := utils.ValidateTLSAtStartup(); err != nil {
+		log.Fatalf("TLS configuration failed: %v", err)
+	}
 
 	var paasCl paasService.PlatformService
 	stubPm := os.Getenv("STUB_PM")
@@ -77,8 +80,14 @@ func main() {
 		}
 	}
 
-	apihubClient := client.NewApihubClient(systemInfoService.GetApihubUrl(), systemInfoService.GetAccessToken(), systemInfoService.GetCloudName())
-	agentsBackendClient := client.NewAgentsBackendClient(systemInfoService.GetApihubUrl(), systemInfoService.GetAccessToken())
+	apihubClient, err := client.NewApihubClient(systemInfoService.GetApihubUrl(), systemInfoService.GetAccessToken(), systemInfoService.GetCloudName())
+	if err != nil {
+		panic(fmt.Sprintf("Can't create APIHUB client: %s", err.Error()))
+	}
+	agentsBackendClient, err := client.NewAgentsBackendClient(systemInfoService.GetApihubUrl(), systemInfoService.GetAccessToken())
+	if err != nil {
+		panic(fmt.Sprintf("Can't create agents-backend client: %s", err.Error()))
+	}
 
 	disablingSerivce := service.NewDisablingService()
 	namespaceListCache := service.NewNamespaceListCache(systemInfoService.GetCloudName(), paasCl, systemInfoService.GetNamespacesCacheTTL())
@@ -96,7 +105,10 @@ func main() {
 	namespaceController := controller.NewNamespaceController(namespaceListCache)
 	serviceController := controller.NewServiceController(serviceListCache, discoveryService, listService)
 	documentController := controller.NewDocumentController(documentService)
-	serviceProxyController := controller.NewServiceProxyController(discoveryService)
+	serviceProxyController, err := controller.NewServiceProxyController(discoveryService)
+	if err != nil {
+		panic(fmt.Sprintf("Can't create service proxy controller: %s", err.Error()))
+	}
 	apiDocsController := controller.NewApiDocsController(systemInfoService.GetBasePath())
 	cloudController := controller.NewCloudController(cloudService)
 	routesController := controller.NewRoutesController(routesService)

--- a/qubership-apihub-agent/service/document_discovery.go
+++ b/qubership-apihub-agent/service/document_discovery.go
@@ -172,7 +172,12 @@ func getDocumentRefsFromApihubConfig(apihubConfig view.JsonMap, timeout time.Dur
 }
 
 func getApihubConfigFromUrls(baseUrl string, paths []string, timeout time.Duration) (view.JsonMap, string, []view.EndpointCallInfo) {
-	client := utils.MakeDiscoveryHttpClient(timeout)
+	client, err := utils.MakeDiscoveryHttpClient(timeout)
+	if err != nil {
+		return nil, "", []view.EndpointCallInfo{{
+			ErrorSummary: fmt.Sprintf("Failed to create discovery HTTP client: %s", err.Error()),
+		}}
+	}
 	var failedCalls []view.EndpointCallInfo
 
 	for _, path := range paths {

--- a/qubership-apihub-agent/utils/discovery.go
+++ b/qubership-apihub-agent/utils/discovery.go
@@ -9,10 +9,18 @@ import (
 	"github.com/Netcracker/qubership-apihub-agent/view"
 )
 
-func MakeDiscoveryHttpClient(timeout time.Duration) http.Client {
-	return http.Client{Timeout: timeout, CheckRedirect: func(req *http.Request, via []*http.Request) error {
-		return http.ErrUseLastResponse
-	}}
+func MakeDiscoveryHttpClient(timeout time.Duration) (http.Client, error) {
+	tlsConfig, err := BuildSecureTLSConfig(nil)
+	if err != nil {
+		return http.Client{}, err
+	}
+	return http.Client{
+		Timeout:   timeout,
+		Transport: &http.Transport{TLSClientConfig: tlsConfig},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}, nil
 }
 
 func EscapeSpaces(s string) string {

--- a/qubership-apihub-agent/utils/tls_utils.go
+++ b/qubership-apihub-agent/utils/tls_utils.go
@@ -1,0 +1,89 @@
+// Copyright 2024-2025 NetCracker Technology Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+var (
+	baseTLSOnce sync.Once
+	baseTLSCfg  *tls.Config
+	baseTLSErr  error
+)
+
+// ValidateTLSAtStartup validates the default TLS configuration at process startup.
+func ValidateTLSAtStartup() error {
+	_, err := BuildSecureTLSConfig(nil)
+	return err
+}
+
+// BuildSecureTLSConfig returns a TLS configuration with proper certificate validation.
+// It uses the system certificate pool.
+//
+// In container deployments based on ghcr.io/netcracker/qubership-core-base, custom CA certificates
+// are loaded into the system trust store by the base image entrypoint from /tmp/cert/ before the
+// application starts. Mount .crt, .cer, or .pem files there in Compose or Kubernetes.
+func BuildSecureTLSConfig(customPEM []byte) (*tls.Config, error) {
+	if len(customPEM) == 0 {
+		baseTLSOnce.Do(func() {
+			baseTLSCfg, baseTLSErr = buildSecureTLSConfig(nil)
+		})
+		if baseTLSErr != nil {
+			return nil, baseTLSErr
+		}
+		return baseTLSCfg.Clone(), nil
+	}
+	return buildSecureTLSConfig(customPEM)
+}
+
+func buildSecureTLSConfig(customPEM []byte) (*tls.Config, error) {
+	rootCAs, err := buildRootCertPool(customPEM)
+	if err != nil {
+		return nil, err
+	}
+	return &tls.Config{
+		RootCAs:    rootCAs,
+		MinVersion: tls.VersionTLS12,
+	}, nil
+}
+
+func buildRootCertPool(customPEM []byte) (*x509.CertPool, error) {
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("load system certificate pool: %w", err)
+	}
+	if len(customPEM) > 0 {
+		if ok := pool.AppendCertsFromPEM(customPEM); !ok {
+			return nil, fmt.Errorf("parse custom PEM certificate")
+		}
+	}
+	return pool, nil
+}
+
+// CreateSecureHTTPClient returns an HTTP client with secure TLS configuration.
+func CreateSecureHTTPClient(timeout time.Duration) (*http.Client, error) {
+	tlsConfig, err := BuildSecureTLSConfig(nil)
+	if err != nil {
+		return nil, err
+	}
+	tr := http.Transport{TLSClientConfig: tlsConfig}
+	return &http.Client{Transport: &tr, Timeout: timeout}, nil
+}


### PR DESCRIPTION
## Summary
- Replaces `InsecureSkipVerify: true` with proper certificate validation via centralized `utils/tls_utils.go` (aligned with [qubership-apihub-backend#456](https://github.com/Netcracker/qubership-apihub-backend/pull/456)).
- **Fail-fast:** TLS certificate pool loading errors propagate and abort startup via `ValidateTLSAtStartup`.
- **Runtime image:** uses `ghcr.io/netcracker/qubership-core-base:2.3.3` instead of plain Alpine — reuses the platform `/tmp/cert/` CA contract.
- Updates APIHUB client, agents-backend client, discovery HTTP client, and service proxy to use secure TLS.

## Certificate contract (core-base)

Custom CA certificates are loaded by the base image entrypoint from `/tmp/cert/` before the app starts. See `helm-templates/README.md` for Kubernetes mount example.

## Related repositories

- **Helm / deployment** (qubership-apihub): optional custom CA mount for agent at `/tmp/cert/` (follow-up, same as backend).

## Test plan

- [x] `go build .` from `qubership-apihub-agent/`
- [ ] Agent starts in core-base image without custom certs (public HTTPS works)
- [ ] Corporate/internal HTTPS works with CA mounted to `/tmp/cert/`
- [ ] Discovery, registration, and service proxy over HTTPS
- [ ] Health probes (`/ready`, `/live`) still pass

Made with [Cursor](https://cursor.com)