### PR TITLE
ci: run agent smoke tests in Kind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
             maintainer=qubership
 
   run-e2e-tests:
-    uses: netcracker/qubership-apihub-ci/.github/workflows/run-e2e-tests-kind.yaml@feature/k8s-ci
+    uses: netcracker/qubership-apihub-ci/.github/workflows/run-e2e-tests-kind.yaml@main
     needs: build-docker-image
     if: github.event_name == 'pull_request'
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,3 @@
-# Copyright 2024-2026 NetCracker Technology Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 name: build Docker image and run agent E2E tests
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 NetCracker Technology Corporation
+# Copyright 2024-2026 NetCracker Technology Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: build Docker image, run E2E BE tests, run E2E FE tests
+name: build Docker image and run agent E2E tests
 
 on:
   push:
     branches:
-      - "**"     
+      - "**"
     tags:
       - '**'
   pull_request:
@@ -40,17 +40,17 @@ jobs:
         labels: |
             maintainer=qubership
 
-  # run-e2e-tests:
-  #   uses: netcracker/qubership-apihub-ci/.github/workflows/run-e2e-tests.yml@main
-  #   needs: build-docker-image
-  #   if: github.event_name == 'pull_request'
-  #   with:
-  #     postman-collections-list: './e2e/1_1_Smoke_Portal.postman_collection.json,./e2e/2_1_Negative_Portal.postman_collection.json,./e2e/3_1_Stories_Bugs.postman_collection.json,./e2e/3_2_Stories_Bugs.postman_collection.json,./e2e/4_Access_control.postman_collection.json'
-  #     apihub-backend-image-tag: ${{ needs.build-docker-image.outputs.image_tag }}
-  #     # apihub-ui-image-tag: dev
-  #     # apihub-build-task-consumer-image-tag: dev
-  #   secrets:
-  #     APIHUB_ACCESS_TOKEN: ${{ secrets.APIHUB_ACCESS_TOKEN }}
-  #     APIHUB_ADMIN_EMAIL: ${{ secrets.APIHUB_ADMIN_EMAIL }}
-  #     APIHUB_ADMIN_PASSWORD: ${{ secrets.APIHUB_ADMIN_PASSWORD }}
-  #     JWT_PRIVATE_KEY: ${{ secrets.JWT_PRIVATE_KEY }}
+  run-e2e-tests:
+    uses: netcracker/qubership-apihub-ci/.github/workflows/run-e2e-tests-kind.yaml@feature/k8s-ci
+    needs: build-docker-image
+    if: github.event_name == 'pull_request'
+    with:
+      postman-collections-list: './e2e/1_1_Smoke_Portal.postman_collection.json,./e2e/1_2_Smoke_Agent.postman_collection.json'
+      playwright-tests-run: false
+      apihub-agent-helm-repository-branch: ${{ github.head_ref }}
+      apihub-agent-image-tag: ${{ needs.build-docker-image.outputs.image_tag }}
+    secrets:
+      APIHUB_ACCESS_TOKEN: ${{ secrets.APIHUB_ACCESS_TOKEN }}
+      APIHUB_ADMIN_EMAIL: ${{ secrets.APIHUB_ADMIN_EMAIL }}
+      APIHUB_ADMIN_PASSWORD: ${{ secrets.APIHUB_ADMIN_PASSWORD }}
+      JWT_PRIVATE_KEY: ${{ secrets.JWT_PRIVATE_KEY }}


### PR DESCRIPTION
## Why
Run the agent smoke suites against the image built for each pull request in a Kind-based APIHUB deployment.

## What
- invoke the reusable Kind E2E workflow from Netcracker/qubership-apihub-ci#69
- deploy the current agent image and Helm chart branch
- run the portal and agent Postman smoke collections with Playwright disabled

## How to verify
- [ ] Confirm the Docker image job succeeds
- [ ] Confirm the Kind E2E job deploys the agent
- [ ] Confirm both Newman smoke collections pass